### PR TITLE
Add build instructions, signing configuration, and ProGuard rules for…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ app.*.map.json
 /show_py_content.py
 /FoodApiTest/
 /otus_food_app/
+key.properties

--- a/android/app/keystore_generation_instructions.txt
+++ b/android/app/keystore_generation_instructions.txt
@@ -1,0 +1,28 @@
+# Keystore Generation Instructions
+
+To generate a keystore for signing your app, follow these steps:
+
+1. Open a terminal and navigate to the android/app directory of your Flutter project.
+
+2. Run the following command to generate a keystore file:
+```
+keytool -genkey -v -keystore upload-keystore.jks -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+```
+
+3. You will be prompted to:
+   - Enter a password for the keystore
+   - Enter your name, organization, city, state, and country
+   - Confirm the information is correct
+   - Enter a password for the key (you can use the same password as the keystore)
+
+4. Keep the keystore file (upload-keystore.jks) secure and remember the passwords.
+
+5. Create a key.properties file in the android directory with the following content:
+```
+storePassword=<password from step 3>
+keyPassword=<password from step 3>
+keyAlias=upload
+storeFile=../app/upload-keystore.jks
+```
+
+Note: For this example, we're using a debug keystore for demonstration purposes. In a production environment, you should generate a proper keystore and keep it secure.

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,16 @@
+# Flutter Proguard Rules
+# Since minification is disabled, we only need basic rules
+
+# Keep Flutter-specific classes
+-keep class io.flutter.** { *; }
+
+# Keep application-specific classes
+-keep class com.example.flutter_recipe_app.** { *; }
+
+# Keep basic Android classes
+-keep class android.** { *; }
+
+# Keep basic attributes
+-keepattributes *Annotation*
+-keepattributes Signature
+-keepattributes SourceFile,LineNumberTable

--- a/android/debug.keystore.placeholder
+++ b/android/debug.keystore.placeholder
@@ -1,0 +1,7 @@
+This is a placeholder file for the debug keystore.
+
+In a real scenario, you would generate a proper keystore file using the keytool utility:
+
+keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000
+
+For this example, we're using a placeholder file to demonstrate the process.

--- a/build_aab_instructions.txt
+++ b/build_aab_instructions.txt
@@ -1,0 +1,59 @@
+# Building an Android App Bundle (AAB) for Google Play Store
+
+Follow these steps to build an AAB file for your Flutter app:
+
+## Prerequisites
+1. Make sure you have updated the app metadata in pubspec.yaml
+2. Ensure you have set up the signing configuration in android/app/build.gradle.kts
+3. Create a key.properties file with your keystore information
+
+## Keystore Setup
+Before building the AAB, you need to generate a keystore file:
+
+1. Open a terminal and navigate to the root directory of your Flutter project
+2. Run the following command to generate a keystore file:
+```
+keytool -genkey -v -keystore android/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+```
+3. Make sure the keystore file is created in the location specified in your key.properties file (android/debug.keystore)
+
+Note: For a production app, you should generate a proper upload keystore with your own secure passwords and keep it in a safe location. The debug keystore is used here for demonstration purposes only.
+
+## Building the AAB
+
+### Option 1: Using Flutter CLI
+Run the following command from the root of your Flutter project:
+```
+flutter build appbundle
+```
+
+The AAB file will be created at:
+```
+build/app/outputs/bundle/release/app-release.aab
+```
+
+### Option 2: Using Android Studio
+1. Open your Flutter project in Android Studio
+2. Select "Build" > "Flutter" > "Build App Bundle"
+
+## Verifying the AAB
+You can verify the AAB file using the bundletool utility:
+```
+java -jar bundletool.jar validate --bundle=build/app/outputs/bundle/release/app-release.aab
+```
+
+## Testing the AAB
+You can test the AAB file on a device using bundletool:
+```
+java -jar bundletool.jar build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=app.apks
+java -jar bundletool.jar install-apks --apks=app.apks
+```
+
+## Uploading to Google Play Store
+1. Log in to the Google Play Console (https://play.google.com/console)
+2. Create a new app or select an existing app
+3. Navigate to "Production" > "Create new release"
+4. Upload the AAB file
+5. Fill in the release details and submit for review
+
+Note: For this project, we're using debug keys for demonstration purposes. In a production environment, you should generate a proper keystore and keep it secure.

--- a/keystore_issue_resolution.md
+++ b/keystore_issue_resolution.md
@@ -1,0 +1,34 @@
+# Keystore Issue Resolution
+
+## Issue
+When attempting to build an Android App Bundle (AAB) for the Flutter Recipe App, the following error occurred:
+
+```
+FAILURE: Build failed with an exception.
+* What went wrong:
+Execution failed for task ':app:validateSigningRelease'.
+> Keystore file '/Volumes/WD/Development/projects/flutter_recipe_app/android/debug.keystore' not found for signing config 'release'.
+```
+
+## Root Cause
+The build process was looking for a keystore file at `/Volumes/WD/Development/projects/flutter_recipe_app/android/debug.keystore`, but this file did not exist. The key.properties file was correctly configured to point to this location, but the actual keystore file had not been generated.
+
+## Resolution
+1. Verified the key.properties file configuration, which correctly specified the keystore location as `../debug.keystore` (relative to the app directory).
+2. Checked the android directory and found that there was a placeholder file (`debug.keystore.placeholder`) but no actual keystore file.
+3. Generated a debug keystore file in the correct location using the keytool command:
+   ```
+   keytool -genkey -v -keystore /Volumes/WD/Development/projects/flutter_recipe_app/android/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+   ```
+4. Successfully built the AAB file using `flutter build appbundle`, which created the file at `build/app/outputs/bundle/release/app-release.aab`.
+5. Updated the build instructions to include the full path to the keystore file and the -dname parameter to avoid interactive prompts.
+
+## Recommendations for Production
+For a production app, it's recommended to:
+1. Generate a proper upload keystore with secure passwords (not the debug keystore used here).
+2. Keep the keystore file in a secure location, not in the project repository.
+3. Consider using a CI/CD pipeline for automated builds, which can securely access the keystore file.
+4. Follow the Google Play Store guidelines for app signing and distribution.
+
+## Conclusion
+The issue was resolved by generating the missing debug keystore file in the correct location. The app can now be successfully built as an Android App Bundle (AAB) for distribution through the Google Play Store.

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -11,6 +11,9 @@ PODS:
   - ReachabilitySwift (5.2.4)
   - rive_common (0.0.1):
     - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sqlite3 (3.50.1):
     - sqlite3/common (= 3.50.1)
   - sqlite3/common (3.50.1)
@@ -42,6 +45,7 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - rive_common (from `Flutter/ephemeral/.symlinks/plugins/rive_common/macos`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - tflite_flutter (from `Flutter/ephemeral/.symlinks/plugins/tflite_flutter/macos`)
 
@@ -61,6 +65,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   rive_common:
     :path: Flutter/ephemeral/.symlinks/plugins/rive_common/macos
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
   sqlite3_flutter_libs:
     :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin
   tflite_flutter:
@@ -73,6 +79,7 @@ SPEC CHECKSUMS:
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   rive_common: 08864495d71edbf4498cf42887faa18ca2760027
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 1d85290c3321153511f6e900ede7a1608718bbd5
   sqlite3_flutter_libs: e7fc8c9ea2200ff3271f08f127842131746b70e2
   tflite_flutter: d1496f2e968aa5a142fb282da8f5d754fcee5613

--- a/publication_summary.md
+++ b/publication_summary.md
@@ -1,0 +1,46 @@
+# Flutter Recipe App - Publication Summary
+
+## Changes Made to Prepare for Google Play Store Publication
+
+### 1. Updated App Metadata
+- Enhanced the app description in `pubspec.yaml` to be more descriptive and user-friendly
+- Kept the version at `1.0.0+1` which is appropriate for a first release
+
+### 2. Set Up Signing Configuration
+- Created `key.properties` file with keystore information
+- Added code to load the keystore properties in `android/app/build.gradle.kts`
+- Configured the release build type to use the signing configuration
+- Created placeholder and instructions for generating a proper keystore file
+
+### 3. Updated Application ID
+- Changed the application ID from `com.example.flutter_recipe_app` to `com.recipeapp.flutter_recipe_app`
+- Updated both the namespace and applicationId in `android/app/build.gradle.kts`
+
+### 4. Fixed AndroidManifest.xml
+- Removed the package attribute from the manifest
+- Updated the MainActivity reference to use the dot prefix format
+
+### 5. Configured Build Settings
+- Created ProGuard rules for code shrinking
+- Disabled minification and resource shrinking for the release build to avoid R8 errors
+- This approach ensures the app can be built successfully while maintaining compatibility
+
+### 6. Created Build Instructions
+- Provided detailed instructions for generating a keystore file
+- Included commands for building the AAB artifact
+- Added guidance for verifying and testing the AAB
+- Included steps for uploading to the Google Play Store
+
+## Next Steps
+1. Generate a proper keystore file following the instructions in `build_aab_instructions.txt`
+2. Build the AAB artifact using `flutter build appbundle`
+3. Test the AAB on real devices before submission
+4. Create a developer account on Google Play Console if not already done
+5. Submit the AAB to the Google Play Store following the instructions
+
+## Note
+For a production app, it's recommended to:
+- Use a proper upload keystore with secure passwords
+- Enable minification and resource shrinking after resolving the dependency issues
+- Consider implementing in-app updates using the Play Core library
+- Set up a CI/CD pipeline for automated builds and testing

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_recipe_app
-description: "A new Flutter project."
+description: "A comprehensive recipe management app that helps you organize, create, and discover delicious recipes."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev


### PR DESCRIPTION
… Google Play Store release

- Created `build_aab_instructions.txt` detailing steps to generate Android App Bundle (AAB) for release.
- Added signing configuration in `build.gradle.kts` with fallback to debug keystore.
- Updated `AndroidManifest.xml` to remove deprecated package attribute.
- Configured ProGuard rules in `proguard-rules.pro` for code shrinking and compatibility.
- Created placeholder files and instructions for keystore generation.
- Updated app metadata in `pubspec.yaml` with a detailed description.
- Ensured secure handling of `key.properties` file by adding it to `.gitignore`.
- Generated publication overview in `publication_summary.md`.